### PR TITLE
Edition fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Trigger *rustfmt* when saving (default = 1):
 g:rustfmt_on_save = 1
 ```
 
-Rust edition to use (default = '2018'):
+Rust edition to use (default = '2021'):
 
 ```vim
 g:rustfmt_edition = '2018'

--- a/ftplugin/rust/rustfmt.vim
+++ b/ftplugin/rust/rustfmt.vim
@@ -25,7 +25,7 @@ function! rustfmt#Rustfmt() range
         return
     endif
 
-    let l:edition_opt = " --edition 2018"
+    let l:edition_opt = " --edition 2021"
     if exists("g:rustfmt_edition")
       let l:edition_opt = " --edition " . g:rustfmt_edition
     endif

--- a/ftplugin/rust/rustfmt.vim
+++ b/ftplugin/rust/rustfmt.vim
@@ -25,20 +25,20 @@ function! rustfmt#Rustfmt() range
         return
     endif
 
+    let l:edition_opt = " --edition 2018"
+    if exists("g:rustfmt_edition")
+      let l:edition_opt = " --edition " . g:rustfmt_edition
+    endif
+
     " Write the buffer to rustfmt, rather than having it use the
     " file on disk, because that file might not have been created yet!
-    silent! w !rustfmt > /dev/null 2>&1
+    silent! exe "w !rustfmt" . l:edition_opt . " > /dev/null 2>&1"
 
     if v:shell_error
         echohl WarningMsg
         echo "Rustfmt: Parsing error\n"
         echohl None
     else
-        let l:edition_opt = " --edition 2018"
-        if exists("g:rustfmt_edition")
-          let l:edition_opt = " --edition " . g:rustfmt_edition
-        endif
-
         let l:backup_opt = ""
         if g:rustfmt_backup == 1
             let l:backup_opt = " --backup"


### PR DESCRIPTION
Hi,

came across two issues with edition handling:

-   `l:edition_opt` wasn’t used for all `rustfmt` calls
-   There’s Rust 2021 now, that should probably be used as a default